### PR TITLE
refactor: refine error handling and add root endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from flask import Flask, request, send_file, jsonify
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from flask_cors import CORS
+from werkzeug.exceptions import HTTPException
 
 # ---------------------------
 # App & CORS
@@ -141,6 +142,8 @@ def get_api_key(name: str) -> str | None:
 # JSON error handler for easier debugging
 @app.errorhandler(Exception)
 def handle_any_error(e):
+    if isinstance(e, HTTPException):
+        return e
     logging.exception("Unhandled error")
     return jsonify({
         "error": "Server error",
@@ -250,6 +253,11 @@ sched.start()
 @app.route('/ping')
 def ping():
     return jsonify({"ok": True, "time": datetime.utcnow().isoformat() + "Z"})
+
+
+@app.route('/', methods=['GET'])
+def index():
+    return jsonify({"status": "CFB Matchup Report Generator running"}), 200
 
 
 @app.route('/generate-report', methods=['POST'])


### PR DESCRIPTION
## Summary
- avoid logging and returning 500 for HTTP-related errors by letting Flask handle `HTTPException`
- add simple `/` route to provide a basic status response

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6561ec2d0832b865599e0af774761