### PR TITLE
Add scoreboard report availability checks and regeneration prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -277,14 +277,19 @@ def generate_report():
     if not all([home_full, away_full, home_short, away_short]):
         return jsonify({"error": "Missing team name parameters"}), 400
 
-    # 3) File path (today)
+    # 3) Check for existing reports regardless of date unless forced
+    force_regen = bool(data.get('force'))
+    pattern = os.path.join(REPORTS_DIR, glob.escape(f"{home_short}_{away_short}_*.pdf"))
+    existing_files = glob.glob(pattern)
+    if existing_files and not force_regen:
+        latest = max(existing_files, key=os.path.getmtime)
+        return jsonify({"message": "Report already exists", "filename": os.path.basename(latest)}), 200
+
+    # Filename for new report (today)
     today = datetime.now()
     date_str = format_friendly_date(today)
     filename = f"{home_short}_{away_short}_{date_str}.pdf"
     filepath = os.path.join(REPORTS_DIR, filename)
-
-    if os.path.isfile(filepath):
-        return jsonify({"message": "Report already exists", "filename": filename}), 200
 
     # 4) Load API keys (short-lived DB connection)
     cfbd_api_key = get_api_key('CFD') or get_api_key('CFBD') or os.getenv('CFBD_API_KEY')
@@ -568,15 +573,31 @@ def get_report():
     if not home_short or not away_short:
         return jsonify({"error": "Missing team name parameters"}), 400
 
-    today = datetime.now()
-    date_str = format_friendly_date(today)
-    filename = f"{home_short}_{away_short}_{date_str}.pdf"
-    filepath = os.path.join(REPORTS_DIR, filename)
-
-    if not os.path.isfile(filepath):
+    pattern = os.path.join(REPORTS_DIR, f"{home_short}_{away_short}_*.pdf")
+    files = glob.glob(pattern)
+    if not files:
         return jsonify({"error": "Report not found. Please generate it first."}), 404
 
+    filepath = max(files, key=os.path.getmtime)
+    filename = os.path.basename(filepath)
+
     return send_file(filepath, mimetype='application/pdf', as_attachment=True, download_name=filename)
+
+
+@app.route('/has-report', methods=['GET'])
+def has_report():
+    api_key_param = request.args.get('api_key')
+    if SERVICE_API_KEY and api_key_param != SERVICE_API_KEY:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    home_short = request.args.get('home_team')
+    away_short = request.args.get('away_team')
+    if not home_short or not away_short:
+        return jsonify({"error": "Missing team name parameters"}), 400
+
+    pattern = os.path.join(REPORTS_DIR, f"{home_short}_{away_short}_*.pdf")
+    files = glob.glob(pattern)
+    return jsonify({"exists": bool(files)}), 200
 
 
 if __name__ == "__main__":

--- a/scoreboard.php
+++ b/scoreboard.php
@@ -326,6 +326,7 @@ if (!empty($otherGames)) {
 const API_BASE = "<?= $AFPLNA_API_BASE ?>";
 const API_KEY  = "<?= $AFPLNA_API_KEY ?>";
 
+window.addEventListener('DOMContentLoaded', () => {
 document.querySelectorAll('.ai-controls').forEach(ctrl => {
   const $gen = ctrl.querySelector('.btn-generate');
   const $dl  = ctrl.querySelector('.btn-download');
@@ -334,9 +335,40 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
   function setStatus(msg, isErr=false) {
     $st.textContent = msg;
     $st.style.color = isErr ? '#c00' : '#0a0';
+    $st.style.backgroundColor = (!isErr && msg) ? '#cfc' : 'transparent';
+    $st.style.padding = (!isErr && msg) ? '2px 4px' : '0';
   }
 
-  function generateReport() {
+  async function checkReportExists(showStatus = false) {
+    const home_short = $gen.dataset.homeshort;
+    const away_short = $gen.dataset.awayshort;
+
+    try {
+      const resp = await fetch(`${API_BASE}/has-report?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}`);
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data && data.exists) {
+          if (showStatus) setStatus('Available!');
+          return true;
+        }
+      }
+    } catch (err) {
+      console.log('Error checking report availability', err);
+    }
+
+    if (showStatus) setStatus('');
+    return false;
+  }
+
+  async function generateReport() {
+    const exists = await checkReportExists(false);
+    let force = false;
+    if (exists) {
+      const proceed = confirm('A report is already available for this game. Do you want to regenerate a newer one?');
+      if (!proceed) return;
+      force = true;
+    }
+
     const home_full  = $gen.dataset.homefull;
     const away_full  = $gen.dataset.awayfull;
     const home_short = $gen.dataset.homeshort;
@@ -350,21 +382,18 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
         api_key: API_KEY,
-        home_full, away_full, home_short, away_short
+        home_full, away_full, home_short, away_short, force
       })
     })
     .then(resp => {
-      // If the request was received, confirm to the user that generation has started
       if (resp && resp.ok) {
         setStatus('Report generation started. This can take up to 5 minutes. Try the download report button after 5 minutes to receive the report.');
       }
     })
     .catch(err => {
-      // Keep the original waiting message if the request fails and log for debugging
       console.log('Network error starting report generation.', err);
     });
 
-    // Re-enable the button shortly since we do not wait for the report to finish generating.
     setTimeout(() => { $gen.disabled = false; }, 1000);
   }
 
@@ -380,8 +409,12 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
     window.location.href = url;
   }
 
+  // Initial availability check on load
+  checkReportExists(true);
+
   $gen.addEventListener('click', generateReport);
   $dl.addEventListener('click', downloadReport);
+});
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Add API endpoint `/has-report` and update `/get-report` to find matchup reports regardless of date
- Highlight existing reports in scoreboard and prompt before regenerating
- Ensure generation checks existing files and allow forced regeneration via `force` flag

## Testing
- `php -l scoreboard.php`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a65c519dd0832bb582c1905ebdc9bc