### PR TITLE
fix: avoid cached has-report results

### DIFF
--- a/scoreboard.php
+++ b/scoreboard.php
@@ -342,9 +342,15 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
   async function checkReportExists(showStatus = false) {
     const home_short = $gen.dataset.homeshort;
     const away_short = $gen.dataset.awayshort;
+    // add a cache-busting query param so the browser doesn't reuse stale
+    // results and incorrectly report that no file exists
+    const ts = Date.now();
 
     try {
-      const resp = await fetch(`${API_BASE}/has-report?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}`);
+      const resp = await fetch(
+        `${API_BASE}/has-report?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}&_=${ts}`,
+        { cache: 'no-store' }
+      );
       if (resp.ok) {
         const data = await resp.json();
         if (data && data.exists) {


### PR DESCRIPTION
## Summary
- prevent stale report availability checks by adding cache-busting parameter and disabling fetch caching

## Testing
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a662b20d68832b99b650cf91898974