### PR TITLE
Fix API calls blocked by missing CORS headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,18 @@ app = Flask(__name__)
 ALLOWED_ORIGIN = os.getenv("ALLOWED_ORIGIN", "*")
 CORS(app, resources={r"/*": {"origins": ALLOWED_ORIGIN}}, supports_credentials=False)
 
+
+@app.after_request
+def ensure_cors_headers(resp):
+    """Guarantee CORS headers are present on every response.
+    The automatic configuration from ``flask_cors`` occasionally misses
+    error responses generated outside of the normal request flow.  By
+    adding this hook we make sure the browser always receives the
+    ``Access-Control-Allow-Origin`` header, preventing fetch requests
+    from being blocked even when the API returns an error."""
+    resp.headers.setdefault("Access-Control-Allow-Origin", ALLOWED_ORIGIN)
+    return resp
+
 try:
     import markdown  # optional for Markdown -> HTML
 except ImportError:

--- a/scoreboard.php
+++ b/scoreboard.php
@@ -350,7 +350,7 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
     try {
       const resp = await fetch(
         `${API_BASE}/has-report?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}&_=${ts}`,
-        { cache: 'no-store' }
+        { cache: 'no-store', mode: 'cors' }
       );
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const data = await resp.json();
@@ -394,6 +394,7 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
 
     fetch(`${API_BASE}/generate-report`, {
       method: 'POST',
+      mode: 'cors',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
         api_key: API_KEY,


### PR DESCRIPTION
## Summary
- Ensure Flask app always attaches `Access-Control-Allow-Origin` header so browsers can read JSON responses
- Make scoreboard fetch calls explicitly use `mode: 'cors'`

## Testing
- `python -m py_compile app.py`
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a687f8bc0c832ba9649f1c2b550a9b