### PR TITLE
Harden CORS and streamline report generation

### DIFF
--- a/scoreboard.php
+++ b/scoreboard.php
@@ -395,10 +395,11 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
     fetch(`${API_BASE}/generate-report`, {
       method: 'POST',
       mode: 'cors',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
+      headers: {'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'},
+      body: new URLSearchParams({
         api_key: API_KEY,
-        home_full, away_full, home_short, away_short, force
+        home_full, away_full, home_short, away_short,
+        force: String(force)
       })
     })
     .then(resp => {


### PR DESCRIPTION
## Summary
- Normalize and strictly check allowed origins, echo credentials for matches, and return 204 for explicit preflights.
- Allow `/generate-report` to accept form submissions alongside JSON for simpler requests.
- Update client fetch to send URL-encoded form data, avoiding CORS preflight.

## Testing
- `python -m py_compile app.py`
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71fdc398c832bbf87285471efd09e