### PR TITLE
Add same-origin PHP relay for AI report

### DIFF
--- a/api/generate_report.php
+++ b/api/generate_report.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+header('Content-Type: application/json; charset=utf-8');
+
+$BASE = 'http://143.198.20.72';
+$ch = curl_init("$BASE/generate-report");
+curl_setopt_array($ch, [
+  CURLOPT_POST=>true,
+  CURLOPT_POSTFIELDS=>file_get_contents('php://input'), // we’ll send JSON or form-URL-encoded verbatim
+  CURLOPT_HTTPHEADER=>[
+    'Content-Type: ' . ($_SERVER['CONTENT_TYPE'] ?? 'application/json')
+  ],
+  CURLOPT_RETURNTRANSFER=>true,
+  CURLOPT_FOLLOWLOCATION=>true,
+  CURLOPT_CONNECTTIMEOUT=>10,
+  CURLOPT_TIMEOUT=>600
+]);
+$body = curl_exec($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE) ?: 502;
+if ($body === false) {
+  http_response_code(502);
+  echo json_encode(['error'=>'upstream','detail'=>curl_error($ch)]);
+  exit;
+}
+http_response_code($code);
+echo $body;

--- a/api/has_report.php
+++ b/api/has_report.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+header('Content-Type: application/json; charset=utf-8');
+
+$BASE = 'http://143.198.20.72';
+$api_key   = $_GET['api_key']   ?? '';
+$home_team = $_GET['home_team'] ?? '';
+$away_team = $_GET['away_team'] ?? '';
+$q = http_build_query([
+  'api_key'=>$api_key, 'home_team'=>$home_team, 'away_team'=>$away_team, '_'=>($_GET['_'] ?? time())
+]);
+
+$ch = curl_init("$BASE/has-report?$q");
+curl_setopt_array($ch, [
+  CURLOPT_RETURNTRANSFER=>true,
+  CURLOPT_FOLLOWLOCATION=>true,
+  CURLOPT_CONNECTTIMEOUT=>10,
+  CURLOPT_TIMEOUT=>30,
+  CURLOPT_HTTPHEADER=>['Accept: application/json'],
+]);
+$body = curl_exec($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE) ?: 502;
+if ($body === false) {
+  http_response_code(502);
+  echo json_encode(['error'=>'upstream','detail'=>curl_error($ch)]);
+  exit;
+}
+http_response_code($code);
+echo $body;

--- a/scoreboard.php
+++ b/scoreboard.php
@@ -345,13 +345,10 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
   async function checkReportExists(showStatus = false) {
     const home_short = $gen.dataset.homeshort;
     const away_short = $gen.dataset.awayshort;
-    const ts = Date.now();
 
     try {
-      const resp = await fetch(
-        `${API_BASE}/has-report?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}&_=${ts}`,
-        { cache: 'no-store', mode: 'cors' }
-      );
+      const chkUrl = `/api/has_report.php?api_key=${encodeURIComponent(API_KEY)}&home_team=${encodeURIComponent(home_short)}&away_team=${encodeURIComponent(away_short)}&_=${Date.now()}`;
+      const resp = await fetch(chkUrl, { cache: 'no-store' });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const data = await resp.json();
 
@@ -392,15 +389,10 @@ document.querySelectorAll('.ai-controls').forEach(ctrl => {
     setStatus('The AI report is being generated. This can take up to 5 minutes. Try the download report button after 5 minutes to receive the report.');
     $gen.disabled = true;
 
-    fetch(`${API_BASE}/generate-report`, {
+    fetch(`/api/generate_report.php`, {
       method: 'POST',
-      mode: 'cors',
       headers: {'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'},
-      body: new URLSearchParams({
-        api_key: API_KEY,
-        home_full, away_full, home_short, away_short,
-        force: String(force)
-      })
+      body: new URLSearchParams({ api_key: API_KEY, home_full, away_full, home_short, away_short, force: String(force) })
     })
     .then(resp => {
       if (resp && resp.ok) {


### PR DESCRIPTION
## Summary
- Add PHP relay for has-report and generate-report API calls
- Update scoreboard.js to use same-origin `/api` proxies

## Testing
- `php -l api/has_report.php`
- `php -l api/generate_report.php`
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a75045b438832ba275a0566c27a490