### PR TITLE
Change missing report message

### DIFF
--- a/scoreboard.php
+++ b/scoreboard.php
@@ -366,15 +366,15 @@ window.addEventListener('DOMContentLoaded', () => {
           $gen.textContent = 'Regenerate AI Report';
           if (showStatus) setStatus('Report is ready ✔');
         } else {
-          $dl.title = 'Report not ready yet';
+          $dl.title = 'Report not yet Generated.';
           $gen.textContent = 'Generate AI Report';
-          if (showStatus) setStatus('Report not ready yet', true);
+          if (showStatus) setStatus('Report not yet Generated.', true);
         }
         return exists;
       } catch (err) {
         console.error('Error checking report availability:', err);
         if (showStatus) setStatus('Error checking report', true);
-        $dl.title = 'Report not ready yet';
+        $dl.title = 'Report not yet Generated.';
         return false;
       }
     }


### PR DESCRIPTION
## Summary
- Show "Report not yet Generated." when no report exists on the scoreboard page.

## Testing
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9f0125be8832ba6a08a3dbe363a85