### PR TITLE
Limit highlight to picked team text

### DIFF
--- a/scoreboard.php
+++ b/scoreboard.php
@@ -223,7 +223,12 @@ mysql_close($connection);
         .score-header .score { font-size: 24px; min-width: 100px; text-align: center; }
         .game-details { padding: 10px; background: #f9f9f9; font-size: 14px; line-height: 1.4; }
         .game-details div { margin: 4px 0; }
-        .your-pick { background-color: yellow; }
+        /* Highlight the user's pick without stretching across the row */
+        .your-pick {
+            background-color: yellow;
+            display: inline-block;
+            padding: 0 4px;
+        }
         .section-title { background: #003366; color: white; padding: 5px; margin-top: 20px; }
         .refresh { margin-bottom: 15px; }
         .team-logo { width: 24px; height: 24px; object-fit: contain; vertical-align: middle; margin-right: 5px; }
@@ -267,7 +272,7 @@ mysql_close($connection);
             echo "<div><b>Weather:</b> " . htmlspecialchars($g['weatherDesc']) . ", Temp " . htmlspecialchars($g['temperature']) . "°, Wind " . htmlspecialchars($g['windDir']) . "° @ " . htmlspecialchars($g['windSpeed']) . " mph</div>";
             echo "<div><b>Lines:</b> Away ML " . htmlspecialchars($g['awayML']) . ", Home ML " . htmlspecialchars($g['homeML']) . ", O/U " . htmlspecialchars($g['overUnder']) . ", Spread " . htmlspecialchars($g['spread']) . "</div>";
             if (!empty($g['yourPick'])) {
-                echo "<div class='your-pick'><b>Your Pick:</b> " . htmlspecialchars($g['yourPick']) . "</div>";
+                echo "<div><span class='your-pick'><b>Your Pick:</b> " . htmlspecialchars($g['yourPick']) . "</span></div>";
             }
             // AI Report controls
             echo '<div class="ai-controls" style="margin:12px 0;">';
@@ -314,7 +319,7 @@ mysql_close($connection);
             echo "<div><b>Weather:</b> " . htmlspecialchars($g['weatherDesc']) . ", Temp " . htmlspecialchars($g['temperature']) . "°, Wind " . htmlspecialchars($g['windDir']) . "° @ " . htmlspecialchars($g['windSpeed']) . " mph</div>";
             echo "<div><b>Lines:</b> Away ML " . htmlspecialchars($g['awayML']) . ", Home ML " . htmlspecialchars($g['homeML']) . ", O/U " . htmlspecialchars($g['overUnder']) . ", Spread " . htmlspecialchars($g['spread']) . "</div>";
             if (!empty($g['yourPick'])) {
-                echo "<div class='your-pick'><b>Your Pick:</b> " . htmlspecialchars($g['yourPick']) . "</div>";
+                echo "<div><span class='your-pick'><b>Your Pick:</b> " . htmlspecialchars($g['yourPick']) . "</span></div>";
             }
             // AI Report controls (for completeness, allow reports on any game)
             echo '<div class="ai-controls" style="margin:12px 0;">';


### PR DESCRIPTION
## Summary
- Show the "Your Pick" highlight only around the team name instead of across the entire row.
- Wrap highlighted text in a `<span>` and add inline-block styling to shrink background to content.

## Testing
- `php -l scoreboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9f2e82230832b85ebbdcc13500dba