### PR TITLE
Use HTTPS for AI report downloads

### DIFF
--- a/scoreboard.php
+++ b/scoreboard.php
@@ -123,8 +123,9 @@ if ($googleResult && $row = mysql_fetch_assoc($googleResult)) {
     mysql_free_result($googleResult);
 }
 
-// ** AFPLNA API Base URL and Key ** 
-$AFPLNA_API_BASE = 'http://143.198.20.72';  // DigitalOcean droplet base (HTTP)
+// ** AFPLNA API Base URL and Key **
+// Use HTTPS to ensure generated reports are downloaded securely
+$AFPLNA_API_BASE = 'https://afplnapicks.com';
 $AFPLNA_API_KEY  = '';
 $afplnaKeyResult = mysql_query("SELECT `KEY` FROM API_KEYS WHERE API_NAME='cfbmatchupreport' LIMIT 1", $connection);
 if ($afplnaKeyResult && $row = mysql_fetch_assoc($afplnaKeyResult)) {


### PR DESCRIPTION
## Summary
- Serve AI report links over HTTPS to remove browser insecure download warnings

## Testing
- `php -l scoreboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68a9f443a048832bb5a693734b8016bd