### PR TITLE
Expand and center watermark on all PDF pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,11 +600,11 @@ def generate_report():
         .hdr {{ display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; background-color:#333; padding:20px; color:white; position:relative; z-index:1; }}
         .hdr img {{ width:100px; height:100px; object-fit:contain; }}
         .content {{ text-align:left; position:relative; z-index:1; }}
-        .watermark {{ position:fixed; top:35%; left:50%; transform:translate(-50%, -50%); opacity:0.1; z-index:0; pointer-events:none; }}
+        .watermark {{ position:fixed; top:0; left:0; width:100%; height:100%; display:flex; justify-content:center; align-items:center; opacity:0.1; z-index:0; pointer-events:none; }}
       </style>
     </head>
     <body>
-      <div class=\"watermark\"><img src=\"data:image/png;base64,{watermark_b64}\" alt=\"AFPLNA watermark\" style=\"width:60%; height:auto;\"></div>
+      <div class=\"watermark\"><img src=\"data:image/png;base64,{watermark_b64}\" alt=\"AFPLNA watermark\" style=\"width:100%; height:auto;\"></div>
       <div class=\"hdr\">
         <img src=\"{home_logo}\" alt=\"{home_full} logo\">
         <div style=\"text-align:center; flex-grow:1;\">


### PR DESCRIPTION
## Summary
- Ensure watermark container spans full page with flex centering so it appears on every PDF page
- Scale watermark image to page width while maintaining aspect ratio

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5d881a178832b9f255d39cb2f38f5