### PR TITLE
Center watermark on each page of PDF report

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,11 +600,12 @@ def generate_report():
         .hdr {{ display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; background-color:#333; padding:20px; color:white; position:relative; z-index:1; }}
         .hdr img {{ width:100px; height:100px; object-fit:contain; }}
         .content {{ text-align:left; position:relative; z-index:1; }}
-        .watermark {{ position:fixed; top:0; left:0; width:100%; height:100%; display:flex; justify-content:center; align-items:center; opacity:0.1; z-index:0; pointer-events:none; }}
+        .watermark {{ position:fixed; top:50%; left:50%; transform:translate(-50%, -50%); opacity:0.1; z-index:0; pointer-events:none; }}
+        .watermark img {{ width:70%; height:auto; }}
       </style>
     </head>
     <body>
-      <div class=\"watermark\"><img src=\"data:image/png;base64,{watermark_b64}\" alt=\"AFPLNA watermark\" style=\"width:100%; height:auto;\"></div>
+      <div class=\"watermark\"><img src=\"data:image/png;base64,{watermark_b64}\" alt=\"AFPLNA watermark\"/></div>
       <div class=\"hdr\">
         <img src=\"{home_logo}\" alt=\"{home_full} logo\">
         <div style=\"text-align:center; flex-grow:1;\">


### PR DESCRIPTION
## Summary
- Adjusted watermark CSS so it centers per page instead of stretching across the document.
- Removed inline styling and added dedicated CSS for the watermark image.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc994888832bae9ce752c07a2697