### PR TITLE
Apply centered watermark to all PDF pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ APScheduler~=3.10
 Markdown~=3.6
 pdfkit~=1.0
 gunicorn~=22.0
+PyPDF2~=3.0
+reportlab~=4.0


### PR DESCRIPTION
## Summary
- Remove HTML-based watermark markup from generated reports
- Post-process PDFs with PyPDF2 and ReportLab to stamp a centered transparent watermark on each page
- Add PyPDF2 and ReportLab dependencies

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5de125b2c832b82b02fa02687be2e