### PR TITLE
Fix watermark to appear on every PDF page

### DIFF
--- a/app.py
+++ b/app.py
@@ -539,8 +539,8 @@ def generate_report():
             position: fixed;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             background: url('data:image/png;base64,{watermark_b64}') center center no-repeat;
             background-size: 70%;
             opacity: 0.1;


### PR DESCRIPTION
## Summary
- ensure the watermark overlay uses viewport units so it spans each PDF page instead of the full document

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4d0b24c832b856c72b33bbbacdb