### PR TITLE
Use fixed-position watermark in PDF reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -530,17 +530,23 @@ def generate_report():
     except Exception as e:
         logging.warning(f"Could not load watermark image: {e}")
 
-    # CSS snippet for watermark (no extra PDF post-processing required)
+    # Watermark elements (fixed-position overlay on each PDF page)
     watermark_css = ""
+    watermark_html = ""
     if watermark_b64:
-        watermark_css = f"""
-        body {{
-            background: url('data:image/png;base64,{watermark_b64}') center center no-repeat;
-            background-size: 70%;
-            background-repeat: repeat-y;
-            background-attachment: fixed;
-        }}
+        watermark_css = """
+        .watermark {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            width: 70%;
+            transform: translate(-50%, -50%);
+            opacity: 0.1;
+            z-index: 0;
+            pointer-events: none;
+        }
         """
+        watermark_html = f"<img src='data:image/png;base64,{watermark_b64}' alt='Watermark' class='watermark' />"
 
     # 10) Build LLM prompt & call Gemini (URL context enabled)
     prompt_intro = (
@@ -616,6 +622,7 @@ def generate_report():
       </style>
     </head>
     <body>
+      {watermark_html}
       <div class=\"hdr\">
         <img src=\"{home_logo}\" alt=\"{home_full} logo\">
         <div style=\"text-align:center; flex-grow:1;\">


### PR DESCRIPTION
## Summary
- replace CSS background watermark with fixed-position `<img>` so wkhtmltopdf repeats it on each page
- inject watermark element and styles before report content, keeping content above via z-index

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b736c28c88832b8433f488eeebd879